### PR TITLE
Fix: LessonMetaRes 조회 로직 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lecture/service/LectureService.java
@@ -150,7 +150,10 @@ public class LectureService {
         // 해당하는 일주일의 기간 중 수업 주기와 일치하는 날짜 뽑아오기
         List<Schedule> schedules = memberAndLecture.getLecture().getSchedules();
         for(LocalDate date = LocalDate.now().minusWeeks(1l).plusDays(1l); date.isBefore(LocalDate.now().plusDays(1l)); date = date.plusDays(1l)) {
-            for(Schedule s : schedules) {;
+            if(date.isBefore(memberAndLecture.getLecture().getStartDate())) {
+                continue;
+            }
+            for(Schedule s : schedules) {
                 if (date.getDayOfWeek().equals(getDayOfWeek(s.getWeekday()))) {
                     Boolean check = true;
                     for(LessonMetaRes l : lessonMetaResList) {


### PR DESCRIPTION
## IssueName
LessonMetaRes 조회 로직 수정

## Description
LessonMetaRes 조회 시, 주기에 맞는 수업들 정보 확인하여 반환하게 되는데, 이 때 시작일 이전인 주기에 해당하는 수업이 만들어지는 케이스 확인. 해당 부분 조건 추가 필요