### PR TITLE
Fix: 특정 Lesson 정보 반환 시, MemberMeta 포함 반환하도록 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/dto/response/LessonRes.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/dto/response/LessonRes.java
@@ -35,7 +35,9 @@ public class LessonRes {
 
     private Schedule time;
 
-    public LessonRes toDto(Lesson lesson, List<HomeworkRes> homeworks) {
+    private List<MemberMeta> memberMetas;
+
+    public LessonRes toDto(Lesson lesson, List<HomeworkRes> homeworks, List<MemberMeta> memberMetas) {
         LessonRes lessonRes = new LessonRes();
         lessonRes.lessonId = lesson.getLessonId();
         lessonRes.lectureId = lesson.getLecture().getLectureId();
@@ -46,6 +48,7 @@ public class LessonRes {
         lessonRes.homeworks = homeworks;
         lessonRes.date = lesson.getDate().toString();
         lessonRes.time = new Schedule(lesson.getWeekday(), lesson.getStartTime(), lesson.getEndTime());
+        lessonRes.memberMetas = memberMetas;
 
         return lessonRes;
     }

--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/service/LessonService.java
@@ -17,6 +17,7 @@ import com.selfrunner.gwalit.domain.lesson.entity.Participant;
 import com.selfrunner.gwalit.domain.lesson.repository.LessonRepository;
 import com.selfrunner.gwalit.domain.member.entity.Member;
 import com.selfrunner.gwalit.domain.member.entity.MemberAndLecture;
+import com.selfrunner.gwalit.domain.member.entity.MemberMeta;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndLectureRepository;
 import com.selfrunner.gwalit.global.exception.ApplicationException;
 import com.selfrunner.gwalit.global.exception.ErrorCode;
@@ -135,8 +136,9 @@ public class LessonService {
 
         // Business Logic
         List<HomeworkRes> homeworkRes = homeworkRepository.findAllByMemberIdAndLessonId(member.getMemberId(), lessonId);
+        List<MemberMeta> memberMetas = memberAndLectureRepository.findMemberMetaByLectureLectureId(lesson.getLecture().getLectureId()).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
 
-        LessonRes lessonRes = new LessonRes().toDto(lesson, homeworkRes);
+        LessonRes lessonRes = new LessonRes().toDto(lesson, homeworkRes, memberMetas);
 
         // Response
         return lessonRes;


### PR DESCRIPTION
## IssueName
특정 Lesson 정보 반환 시, MemberMeta 포함 반환하도록 수정

## Description
수업 리포트 반환 시, 학생들 이름을 띄우기 위한 membermeta 정보 필요
이에 따른, membermeta 정보 추가 반환