### PR TITLE
Fix: Homework 리스트 조회 시, lectureId를 Parameter로 활용할 수 있도록 수정 #166

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/homework/controller/HomeworkController.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/homework/controller/HomeworkController.java
@@ -70,7 +70,7 @@ public class HomeworkController {
 
     @Operation(summary = "학생이 가지고 있는 모든 숙제 리스트 반환")
     @GetMapping("/list")
-    public ApplicationResponse<List<HomeworkMainRes>> getList(@Auth Member member, @RequestParam("type") String type) {
-        return ApplicationResponse.ok(ErrorCode.SUCCESS, homeworkService.getList(member, type));
+    public ApplicationResponse<List<HomeworkMainRes>> getList(@Auth Member member, @RequestParam(value = "lectureId", required = false) Long lectureId, @RequestParam("type") String type) {
+        return ApplicationResponse.ok(ErrorCode.SUCCESS, homeworkService.getList(member, lectureId, type));
     }
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/homework/repository/HomeworkRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/homework/repository/HomeworkRepositoryCustom.java
@@ -22,4 +22,10 @@ public interface HomeworkRepositoryCustom {
     Optional<List<HomeworkMainRes>> findAllHomeworkByMemberAndType(Member member, Boolean type);
 
     HomeworkMainRes findHomeworkByHomeworkId(Long homeworkId);
+
+    Optional<List<HomeworkMainRes>> findAllHomeworkByMemberAndLectureId(Member member, Long lectureId);
+
+    Optional<List<HomeworkMainRes>> findAllHomeworkByMemberAndLectureIdAndType(Member member, Long lectureId, Boolean type);
+
+
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/homework/repository/HomeworkRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/homework/repository/HomeworkRepositoryImpl.java
@@ -88,4 +88,26 @@ public class HomeworkRepositoryImpl implements HomeworkRepositoryCustom{
                 .fetchOne();
 
     }
+
+    @Override
+    public Optional<List<HomeworkMainRes>> findAllHomeworkByMemberAndLectureId(Member member, Long lectureId) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(homework)
+                        .leftJoin(lesson).on(lesson.lessonId.eq(homework.lessonId))
+                        .leftJoin(lecture).on(lecture.lectureId.eq(lesson.lecture.lectureId))
+                        .where(homework.memberId.eq(member.getMemberId()), homework.deletedAt.isNull(), lecture.lectureId.eq(lectureId))
+                        .transform(groupBy(homework.homeworkId).list(Projections.constructor(HomeworkMainRes.class, homework.homeworkId, lecture.lectureId, lecture.color, lesson.lessonId, homework.memberId, homework.body, homework.deadline, homework.isFinish)))
+        );
+    }
+
+    @Override
+    public Optional<List<HomeworkMainRes>> findAllHomeworkByMemberAndLectureIdAndType(Member member, Long lectureId, Boolean type) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(homework)
+                        .leftJoin(lesson).on(lesson.lessonId.eq(homework.lessonId))
+                        .leftJoin(lecture).on(lecture.lectureId.eq(lesson.lecture.lectureId))
+                        .where(homework.memberId.eq(member.getMemberId()), homework.isFinish.eq(type), homework.deletedAt.isNull(), lecture.lectureId.eq(lectureId))
+                        .transform(groupBy(homework.homeworkId).list(Projections.constructor(HomeworkMainRes.class, homework.homeworkId, lecture.lectureId, lecture.color, lesson.lessonId, homework.memberId, homework.body, homework.deadline, homework.isFinish)))
+        );
+    }
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/homework/service/HomeworkService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/homework/service/HomeworkService.java
@@ -140,7 +140,7 @@ public class HomeworkService {
         return homeworkMainResList;
     }
 
-    public List<HomeworkMainRes> getList(Member member, String type) {
+    public List<HomeworkMainRes> getList(Member member, Long lectureId, String type) {
         // Validation - 학생용 API
         if(member.getType().equals(MemberType.TEACHER)) {
             throw new MemberException(ErrorCode.UNAUTHORIZED_EXCEPTION);
@@ -148,14 +148,27 @@ public class HomeworkService {
 
         // Business Logic - all: 전체 리스트 / finished: 완료 리스트 / unfinished: 미완료 리스트
         List<HomeworkMainRes> homeworkMainResList = new ArrayList<>();
-        if(type.equals("all")) {
-            homeworkMainResList = homeworkRepository.findAllHomeworkByMember(member).orElse(null);
+        if(lectureId == null) {
+            if(type.equals("all")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMember(member).orElse(null);
+            }
+            if(type.equals("finished")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndType(member, Boolean.TRUE).orElse(null);
+            }
+            if(type.equals("unfinished")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndType(member, Boolean.FALSE).orElse(null);
+            }
         }
-        if(type.equals("finished")) {
-            homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndType(member, Boolean.TRUE).orElse(null);
-        }
-        if(type.equals("unfinished")) {
-            homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndType(member, Boolean.FALSE).orElse(null);
+        if(lectureId != null) {
+            if(type.equals("all")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndLectureId(member, lectureId).orElse(null);
+            }
+            if(type.equals("finished")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndLectureIdAndType(member, lectureId, Boolean.TRUE).orElse(null);
+            }
+            if(type.equals("unfinished")) {
+                homeworkMainResList = homeworkRepository.findAllHomeworkByMemberAndLectureIdAndType(member, lectureId, Boolean.FALSE).orElse(null);
+            }
         }
 
 


### PR DESCRIPTION
## IssueName
Homework 리스트 조회 API 수정 #166 

## Description
Homework 리스트 조회 API에서, requestparam으로 lectureId를 포함하여, parameter가 없을 경우와 있는 경우에 따라 조건 분기로 데이터 반환하도록 수정