### PR TITLE
Fix: 선생님 회원 탈퇴 시, 관련 데이터 모두 삭제되도록 변경

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lecture/repository/LectureRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lecture/repository/LectureRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface LectureRepositoryCustom {
     Optional<List<GetLectureMainRes>> findAllLectureMainByLectureIdList(List<Long> lectureIdList);
 
     Optional<List<GetLectureMetaRes>> findAllLectureMetaByLectureIdList(List<Long> lectureIdList);
+
+    void deleteAllByLectureIdList(List<Long> lectureIdList);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lecture/repository/LectureRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.selfrunner.gwalit.domain.member.entity.MemberMeta;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,5 +55,13 @@ public class LectureRepositoryImpl implements LectureRepositoryCustom{
                 .transform(groupBy(lecture.lectureId)
                         .list(Projections.constructor(GetLectureMetaRes.class, lecture.lectureId, lecture.name, lecture.color, lecture.subject, lecture.subjectDetail, lecture.startDate, lecture.endDate, lecture.schedules,
                                 list(Projections.constructor(MemberMeta.class, member.memberId, member.name, memberAndLecture.isTeacher))))));
+    }
+
+    @Override
+    public void deleteAllByLectureIdList(List<Long> lectureIdList) {
+        queryFactory.update(lecture)
+                .set(lecture.deletedAt, LocalDateTime.now())
+                .where(lecture.lectureId.in(lectureIdList))
+                .execute();
     }
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryCustom.java
@@ -28,4 +28,8 @@ public interface LessonRepositoryCustom {
     Optional<Long> findRecentLessonIdByLectureId(Long lectureId);
 
     Optional<List<Long>> findRecentLessonIdByLectureIdList(List<Long> lectureId);
+
+    List<Long> findAllLessonIdByLectureIdList(List<Long> lectureIdList);
+
+    void deleteAllByLectureLectureIdList(List<Long> lectureIdList);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryImpl.java
@@ -133,4 +133,20 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom{
                     .transform(groupBy(lesson.lecture.lectureId).list(lesson.lessonId))
         );
     }
+
+    @Override
+    public List<Long> findAllLessonIdByLectureIdList(List<Long> lectureIdList) {
+        return queryFactory.select(lesson.lessonId)
+                        .from(lesson)
+                        .where(lesson.lecture.lectureId.in(lectureIdList))
+                        .fetch();
+    }
+
+    @Override
+    public void deleteAllByLectureLectureIdList(List<Long> lectureIdList) {
+        queryFactory.update(lesson)
+                .set(lesson.deletedAt, LocalDateTime.now())
+                .where(lesson.lecture.lectureId.in(lectureIdList))
+                .execute();
+    }
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/member/service/AuthService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/member/service/AuthService.java
@@ -1,6 +1,9 @@
 package com.selfrunner.gwalit.domain.member.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.selfrunner.gwalit.domain.homework.repository.HomeworkRepository;
+import com.selfrunner.gwalit.domain.lecture.repository.LectureRepository;
+import com.selfrunner.gwalit.domain.lesson.repository.LessonRepository;
 import com.selfrunner.gwalit.domain.member.dto.request.PostAuthCodeReq;
 import com.selfrunner.gwalit.domain.member.dto.request.PostAuthPhoneReq;
 import com.selfrunner.gwalit.domain.member.dto.request.PostLoginReq;
@@ -13,6 +16,7 @@ import com.selfrunner.gwalit.domain.member.entity.MemberType;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndLectureRepository;
 import com.selfrunner.gwalit.domain.member.exception.MemberException;
 import com.selfrunner.gwalit.domain.member.repository.MemberRepository;
+import com.selfrunner.gwalit.domain.task.repository.TaskRepository;
 import com.selfrunner.gwalit.global.exception.ApplicationException;
 import com.selfrunner.gwalit.global.exception.ErrorCode;
 import com.selfrunner.gwalit.global.util.SHA256;
@@ -42,6 +46,10 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
     private final MemberAndLectureRepository memberAndLectureRepository;
+    private final LectureRepository lectureRepository;
+    private final LessonRepository lessonRepository;
+    private final HomeworkRepository homeworkRepository;
+    private final TaskRepository taskRepository;
 
     public Void sendAuthorizationCode(PostAuthPhoneReq postAuthPhoneReq) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException, URISyntaxException {
         // Business Logic
@@ -184,7 +192,15 @@ public class AuthService {
 
         // Business Logic: Soft Delete
         memberRepository.delete(member);
+        List<Long> lectureIdList = memberAndLectureRepository.findLectureIdByMember(member).orElse(null);
         memberAndLectureRepository.deleteMemberAndLecturesByMember(member);
+        if(lectureIdList != null && member.getType().equals(MemberType.TEACHER)) {
+            taskRepository.deleteAllByLectureIdList(lectureIdList);
+            List<Long> lessonIdList = lessonRepository.findAllLessonIdByLectureIdList(lectureIdList);
+            homeworkRepository.deleteAllByLessonIdList(lessonIdList);
+            lessonRepository.deleteAllByLectureLectureIdList(lectureIdList);
+            lectureRepository.deleteAllByLectureIdList(lectureIdList);
+        }
 
         // Response
         return null;

--- a/src/main/java/com/selfrunner/gwalit/domain/task/repository/TaskRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/task/repository/TaskRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface TaskRepositoryCustom {
     Optional<List<TaskRes>> findAllByMemberId(Member member);
 
     Optional<List<TaskRes>> findTasksByLectureLectureIdOrderByDeadlineDesc(Long lectureId);
+
+    void deleteAllByLectureIdList(List<Long> lectureIdList);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/task/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/task/repository/TaskRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.selfrunner.gwalit.domain.task.dto.response.TaskRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +42,14 @@ public class TaskRepositoryImpl implements TaskRepositoryCustom{
                 .where(lecture.lectureId.eq(lectureId))
                 .transform(groupBy(task.taskId)
                         .list(Projections.constructor(TaskRes.class, task.taskId, task.lecture.lectureId, lecture.color, task.title, task.deadline, task.isPinned, task.subtasks))));
+    }
+
+    @Override
+    public void deleteAllByLectureIdList(List<Long> lectureIdList) {
+        queryFactory.update(task)
+                .set(task.deletedAt, LocalDateTime.now())
+                .where(task.lecture.lectureId.in(lectureIdList))
+                .execute();
     }
 
 }


### PR DESCRIPTION
## IssueName
선생님 회원 탈퇴 시, 클래스 삭제되는 로직 추가

## Description
선생님이 클래스를 지우지 않고, 회원 탈퇴 시 클래스는 삭제되지 않는 현재 로직에 의하면, 학생이 해당 클래스를 보게 되면, 클라이언트 뷰 상에서 오류가 발생함.