### PR TITLE
Fix: 윤년 고려하도록 조건 수정 #186

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lecture/service/LectureService.java
@@ -59,7 +59,7 @@ public class LectureService {
         if(memberAndLectureRepository.findCountByMember(member) > 3) {
             throw new LectureException(ErrorCode.FAILED_MAKE_CLASS);
         }
-        if(ChronoUnit.DAYS.between(postLectureReq.getStartDate(), postLectureReq.getEndDate()) > 365) {
+        if(postLectureReq.getEndDate().isAfter(postLectureReq.getStartDate().plusYears(1).minusDays(1))) {
             throw new LectureException(ErrorCode.INVALID_VALUE_EXCEPTION);
         }
         if(postLectureReq.getSchedules().size() > 20) {


### PR DESCRIPTION
## IssueName
Lecture 시작일 종료일 기간 산정 오류 수정 #186 

## Description
Lecture 시작일 종료일 기간의 제한이 1년으로 잡혀 있는데, 현재는 윤년에 대한 고려 없이 365일로만 조건이 잡혀있다. 이 부분을 윤년까지 고려하기 위해서, 1년이라는 기간 산정 방식의 수정이 필요함을 파악하여 수정 진해