### PR TITLE
Fix: 학생 정보 수정 시, 학교 정보가 null로 적용될 수 있도록 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/member/entity/Member.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/member/entity/Member.java
@@ -68,7 +68,7 @@ public class Member extends BaseTimeEntity {
 
     public void update(PutMemberReq putMemberReq) {
         this.name = putMemberReq.getName();
-        this.school = (putMemberReq.getSchool() != null) ? putMemberReq.getSchool() : this.school;
+        this.school = putMemberReq.getSchool();
         this.grade = (putMemberReq.getGrade() != null) ? MemberGrade.valueOf(putMemberReq.getGrade()) : this.grade;
         this.isAdvertisement = putMemberReq.getIsAdvertisement();
         this.isPrivacy = putMemberReq.getIsPrivacy();


### PR DESCRIPTION
## IssueName
학생 회원정보 수정 시, 변경 안 되는 오류 수정

## Description
학생 회원 정보 수정 시, 학교 정보를 null로 보내도, 변경 적용 되도록 수정