### PR TITLE
Hotfix: Feedback Column type 확장

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/entity/Lesson.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/entity/Lesson.java
@@ -48,7 +48,7 @@ public class Lesson extends BaseTimeEntity {
     @Column(name = "participants", columnDefinition = "json")
     private List<Participant> participants;
 
-    @Column(name = "feedback")
+    @Column(name = "feedback", columnDefinition = "text")
     private String feedback;
 
     @Type(type = "json")


### PR DESCRIPTION
# IssueName
Feedback Column type 확장

## Description
[Sentry 이슈](https://gwarit-b6ac5772e.sentry.io/issues/4544901506/?project=4505729825243136&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0)
와 같이, feedback 칼럼에 255자 이상의 글자수를 입력하는 경우, 오류가 발생함. 
해당 부분 column type text 변경 및 적용 진행