### PR TITLE
Fix: 학생이 이름, 색상 변경 시 적용 오류 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/member/entity/MemberAndLecture.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/member/entity/MemberAndLecture.java
@@ -55,7 +55,7 @@ public class MemberAndLecture extends BaseTimeEntity {
     }
 
     public void updateIsUpdate() {
-        this.isUpdate = !this.isUpdate;
+        this.isUpdate = Boolean.FALSE; // 한 번이라도 학생이 변경 시도하면 Boolean.TRUE 값 고정되어야 함.
     }
 
     @Builder


### PR DESCRIPTION
## IssueName
학생이 이름, 색상 변경 시 적용 오류 수정 #239 

## Description
현재 상황
1. 선생님이 학생 초대 시, 학생은 선생님의 색깔 그대로 적용
2. 학생이 이름, 색상 변경을 한 번이라도 하지 않았을 경우, 학생은 선생님이 변경한 값을 계속 따라감
3. 학생이 이름, 색상을 한 번이라도 변경하면 선생님이 변경한 값을 따라가지 않음.
4. 그러나 리로딩하면 학생이 변경한 값이 롤백되는 현상 발생