### PR TITLE
Fix: 수업리포트 수정 API 선생님 권한 조건 추가

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/service/LessonService.java
@@ -20,6 +20,7 @@ import com.selfrunner.gwalit.domain.lesson.repository.LessonRepository;
 import com.selfrunner.gwalit.domain.member.entity.Member;
 import com.selfrunner.gwalit.domain.member.entity.MemberAndLecture;
 import com.selfrunner.gwalit.domain.member.entity.MemberMeta;
+import com.selfrunner.gwalit.domain.member.entity.MemberType;
 import com.selfrunner.gwalit.domain.member.exception.MemberException;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndLectureRepository;
 import com.selfrunner.gwalit.global.common.Schedule;
@@ -72,6 +73,9 @@ public class LessonService {
     @Transactional
     public LessonRes update(Member member, Long lessonId, PutLessonReq putLessonReq) {
         // Validation
+        if(!member.getType().equals(MemberType.TEACHER)) {
+            throw new LessonException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+        }
         Lesson lesson = lessonRepository.findById(lessonId).orElseThrow(() -> new LessonException(ErrorCode.NOT_EXIST_LESSON));
         MemberAndLecture memberAndLecture = memberAndLectureRepository.findMemberAndLectureByMemberAndLectureLectureId(member, lesson.getLecture().getLectureId()).orElseThrow(() -> new MemberException(ErrorCode.UNAUTHORIZED_EXCEPTION));
 


### PR DESCRIPTION
## IssueName
수업리포트 수정 시, 권한 확인 조건 추가

## Description
수업리포트 수정 API에서 선생님만 가능하도록 권한 제어 추가