### PR TITLE
Feat: 게시글 API 추가 및 로직 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardReplyRes.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardReplyRes.java
@@ -9,6 +9,7 @@ import com.selfrunner.gwalit.domain.member.entity.MemberType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,6 +32,8 @@ public class BoardReplyRes {
 
     private Long lessonId;
 
+    private LocalDate lessonDate;
+
     private final String title;
 
     private String body;
@@ -47,7 +50,7 @@ public class BoardReplyRes {
 
     private final LocalDateTime modifiedAt;
 
-    public BoardReplyRes(Board board, Member member, Integer replyCount, List<FileRes> fileList) {
+    public BoardReplyRes(Board board, Member member, LocalDate lessonDate, Integer replyCount, List<FileRes> fileList) {
         this.boardId = board.getBoardId();
         this.lectureId = board.getLecture().getLectureId();
         this.memberId = member.getMemberId();
@@ -55,6 +58,7 @@ public class BoardReplyRes {
         this.memberName = member.getName();
         this.isPublic = board.getIsPublic();
         this.lessonId = board.getLessonId();
+        this.lessonDate = lessonDate;
         this.title = board.getTitle();
         this.body = board.getBody();
         this.category = board.getCategory();

--- a/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardReplyRes.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardReplyRes.java
@@ -43,13 +43,11 @@ public class BoardReplyRes {
 
     private Integer replyCount;
 
-    private List<ReplyRes> replyList;
-
     private final LocalDateTime createdAt;
 
     private final LocalDateTime modifiedAt;
 
-    public BoardReplyRes(Board board, Member member, Integer replyCount, List<FileRes> fileList, List<ReplyRes> replyList) {
+    public BoardReplyRes(Board board, Member member, Integer replyCount, List<FileRes> fileList) {
         this.boardId = board.getBoardId();
         this.lectureId = board.getLecture().getLectureId();
         this.memberId = member.getMemberId();
@@ -63,7 +61,6 @@ public class BoardReplyRes {
         this.status = board.getStatus();
         this.fileList = fileList;
         this.replyCount = replyCount;
-        this.replyList = replyList;
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
     }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardRes.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/dto/response/BoardRes.java
@@ -9,6 +9,7 @@ import com.selfrunner.gwalit.domain.member.entity.MemberType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,6 +32,8 @@ public class BoardRes {
 
     private final Long lessonId;
 
+    private final LocalDate lessonDate;
+
     private final String title;
 
     private final String body;
@@ -45,7 +48,7 @@ public class BoardRes {
 
     private final LocalDateTime modifiedAt;
 
-    public BoardRes(Board board, Member member, List<FileRes> fileList) {
+    public BoardRes(Board board, Member member, LocalDate lessonDate, List<FileRes> fileList) {
         this.boardId = board.getBoardId();
         this.lectureId = board.getLecture().getLectureId();
         this.memberId = member.getMemberId();
@@ -53,6 +56,7 @@ public class BoardRes {
         this.memberName = member.getName();
         this.isPublic = board.getIsPublic();
         this.lessonId = board.getLessonId();
+        this.lessonDate = lessonDate;
         this.title = board.getTitle();
         this.body = board.getBody();
         this.category = board.getCategory();

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryImpl.java
@@ -67,7 +67,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 .leftJoin(reply).on(reply.board.boardId.eq(board.boardId))
                 .leftJoin(memberAndLecture).on(memberAndLecture.lecture.lectureId.eq(board.lecture.lectureId))
                 .leftJoin(member).on(member.memberId.eq(memberAndLecture.member.memberId))
-                .where(memberAndLecture.member.memberId.eq(memberId), board.status.eq(QuestionStatus.UNSOLVED), board.deletedAt.isNull())
+                .where(memberAndLecture.member.memberId.eq(memberId), board.category.eq(BoardCategory.QUESTION), board.status.eq(QuestionStatus.UNSOLVED), board.deletedAt.isNull())
                 .groupBy(board.boardId)
                 .orderBy(board.createdAt.desc())
                 .transform(groupBy(board.boardId).list(Projections.constructor(BoardMetaRes.class, board.boardId, memberAndLecture.lecture.lectureId, member.memberId, member.type, member.name, board.lessonId, board.title, board.body, board.category, board.status, reply.board.boardId.count(), board.createdAt, board.modifiedAt)));

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryImpl.java
@@ -38,7 +38,7 @@ public class FileRepositoryImpl implements FileRepositoryCustom{
     public Optional<List<FileRes>> findAllByBoardId(Long boardId) {
         return Optional.ofNullable(
                 queryFactory.selectFrom(file)
-                        .where(file.boardId.eq(boardId), file.deletedAt.isNull())
+                        .where(file.boardId.eq(boardId), file.replyId.isNull(), file.deletedAt.isNull())
                         .transform(groupBy(file.url).list(Projections.constructor(FileRes.class, file.name, file.url, file.size)))
         );
     }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryCustom.java
@@ -13,9 +13,6 @@ public interface ReplyRepositoryCustom {
     // 게시글의 총 댓글 수 조회
     Integer findReplyCountByBoardId(Long boardId);
 
-    // 특정 게시글의 최근 5개 댓글 반환
-    Optional<List<ReplyRes>> findRecentReplyByBoardId(Long boardId);
-
     // 댓글 페이지네이션
     Slice<ReplyRes> findReplyPaginationByBoardId(Long boardId, Long cursor, LocalDateTime cursorCreatedAt, Pageable pageable);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryImpl.java
@@ -58,7 +58,7 @@ public class ReplyRepositoryImpl implements ReplyRepositoryCustom{
                 .leftJoin(member).on(reply.member.memberId.eq(member.memberId))
                 .leftJoin(file).on(reply.replyId.eq(file.replyId))
                 .where(reply.board.boardId.eq(boardId), eqCursorIdAndCursorCreatedAt(cursor, cursorCreatedAt), reply.deletedAt.isNull())
-                .orderBy(reply.createdAt.desc(), reply.replyId.asc())
+                .orderBy(reply.createdAt.asc(), reply.replyId.asc())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
@@ -78,7 +78,7 @@ public class ReplyRepositoryImpl implements ReplyRepositoryCustom{
             return null;
         }
 
-        return reply.createdAt.lt(cursorCreatedAt)
+        return reply.createdAt.gt(cursorCreatedAt)
                 .or(reply.replyId.gt(cursor)
                         .and(reply.createdAt.eq(cursorCreatedAt)));
     }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/ReplyRepositoryImpl.java
@@ -36,21 +36,6 @@ public class ReplyRepositoryImpl implements ReplyRepositoryCustom{
                 .fetchFirst().intValue();
     }
 
-    @Override
-    public Optional<List<ReplyRes>> findRecentReplyByBoardId(Long boardId) {
-        return Optional.ofNullable(
-            queryFactory.selectFrom(reply)
-                    .leftJoin(board).on(reply.board.boardId.eq(board.boardId))
-                    .leftJoin(member).on(reply.member.memberId.eq(member.memberId))
-                    .leftJoin(file).on(file.replyId.eq(reply.replyId))
-                    .where(reply.board.boardId.eq(boardId), reply.deletedAt.isNull())
-                    .orderBy(reply.createdAt.desc())
-                    .limit(10)
-                    .transform(groupBy(reply.replyId).list(Projections.constructor(ReplyRes.class, reply.replyId, board.boardId, member.memberId, member.type, member.name, reply.body,
-                            list(Projections.constructor(FileRes.class, file.name, file.url, file.size)), reply.createdAt, reply.modifiedAt)))
-        );
-    }
-
     public Slice<ReplyRes> findReplyPaginationByBoardId(Long boardId, Long cursor, LocalDateTime cursorCreatedAt, Pageable pageable) {
         List<ReplyRes> content = queryFactory.select(Projections.constructor(ReplyRes.class, reply.replyId, reply.board.boardId, member.memberId, member.type, member.name, reply.body,
                         list(Projections.constructor(FileRes.class, file.name, file.url, file.size)), reply.createdAt, reply.modifiedAt))

--- a/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
@@ -16,6 +16,7 @@ import com.selfrunner.gwalit.domain.board.repository.BoardRepository;
 import com.selfrunner.gwalit.domain.board.repository.FileJdbcRepository;
 import com.selfrunner.gwalit.domain.board.repository.FileRepository;
 import com.selfrunner.gwalit.domain.board.repository.ReplyRepository;
+import com.selfrunner.gwalit.domain.lesson.repository.LessonRepository;
 import com.selfrunner.gwalit.domain.member.entity.*;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndLectureRepository;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndNotificationJdbcRepository;
@@ -34,6 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +51,7 @@ public class BoardService {
     private final FileRepository fileRepository;
     private final FileJdbcRepository fileJdbcRepository;
     private final MemberRepository memberRepository;
+    private final LessonRepository lessonRepository;
     private final MemberAndLectureRepository memberAndLectureRepository;
     private final NotificationRepository notificationRepository;
     private final MemberAndNotificationJdbcRepository memberAndNotificationJdbcRepository;
@@ -67,13 +70,14 @@ public class BoardService {
         // Business Logic
         Board board = postBoardReq.toEntity(memberAndLecture.getLecture(), member);
         Board saveBoard = boardRepository.save(board);
+        LocalDate lessonDate = (board.getLessonId() != null) ? lessonRepository.findLessonDateByLessonId(board.getLessonId()).orElse(null) : null;
         // File이 존재하면 S3 업로드 진행
         List<FileRes> fileUrlList = (multipartFileList != null) ? uploadFileList(multipartFileList, member.getMemberId(), memberAndLecture.getLecture().getLectureId(), saveBoard.getBoardId(), null): null;
         // FCM 알림 전송
         sendBoardNotification(member, memberAndLecture, board);
 
         // Response
-        return new BoardRes(saveBoard, member, fileUrlList);
+        return new BoardRes(saveBoard, member, lessonDate, fileUrlList);
     }
 
     @Transactional
@@ -92,10 +96,11 @@ public class BoardService {
         deleteFileList(putBoardReq.getDeleteFileList());
         board.update(putBoardReq);
         Board updateBoard = boardRepository.save(board);
+        LocalDate lessonDate = (board.getLessonId() != null) ? lessonRepository.findLessonDateByLessonId(board.getLessonId()).orElse(null) : null;
         List<FileRes> fileResList = (multipartFileList != null) ? uploadFileList(multipartFileList, member.getMemberId(), board.getLecture().getLectureId(), boardId, null) : null;
 
         // Response
-        return new BoardRes(updateBoard, member, fileResList);
+        return new BoardRes(updateBoard, member, lessonDate, fileResList);
     }
 
     @Transactional
@@ -131,12 +136,12 @@ public class BoardService {
 
         // Business Logic
         board.changeQuestionStatus();
-        System.out.println(board.getStatus());
         Board updateBoard = boardRepository.save(board);
+        LocalDate lessonDate = (board.getLessonId() != null) ? lessonRepository.findLessonDateByLessonId(board.getLessonId()).orElse(null) : null;
         List<FileRes> fileList = fileRepository.findAllByBoardId(boardId).orElse(null);
 
         // Response
-        return new BoardRes(updateBoard, updateBoard.getMember(), fileList);
+        return new BoardRes(updateBoard, updateBoard.getMember(), lessonDate, fileList);
     }
 
     public BoardReplyRes getOneBoard(@Auth Member member, Long boardId) {
@@ -149,11 +154,12 @@ public class BoardService {
         }
 
         // Business Logic
+        LocalDate lessonDate = (board.getLessonId() != null) ? lessonRepository.findLessonDateByLessonId(board.getLessonId()).orElse(null) : null;
         List<FileRes> fileList = fileRepository.findAllByBoardId(boardId).orElse(null);
         Integer replyCount = replyRepository.findReplyCountByBoardId(boardId);
 
         // Response
-        return new BoardReplyRes(board, board.getMember(), replyCount, fileList);
+        return new BoardReplyRes(board, board.getMember(), lessonDate, replyCount, fileList);
     }
 
     public Slice<BoardMetaRes> getBoardPagination(Member member, Long lectureId, String category, Long cursor, Pageable pageable) {

--- a/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
@@ -150,11 +150,10 @@ public class BoardService {
 
         // Business Logic
         List<FileRes> fileList = fileRepository.findAllByBoardId(boardId).orElse(null);
-        List<ReplyRes> replyList = replyRepository.findRecentReplyByBoardId(boardId).orElse(null);
         Integer replyCount = replyRepository.findReplyCountByBoardId(boardId);
 
         // Response
-        return new BoardReplyRes(board, board.getMember(), replyCount, fileList, replyList);
+        return new BoardReplyRes(board, board.getMember(), replyCount, fileList);
     }
 
     public Slice<BoardMetaRes> getBoardPagination(Member member, Long lectureId, String category, Long cursor, Pageable pageable) {

--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryCustom.java
@@ -38,4 +38,6 @@ public interface LessonRepositoryCustom {
     void updateLessonProcessingByDate(List<Long> lessonIdList);
 
     void updateLessonSentByDate(List<Long> lessonIdList);
+
+    Optional<LocalDate> findLessonDateByLessonId(Long lessonId);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/lesson/repository/LessonRepositoryImpl.java
@@ -182,4 +182,14 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom{
                 .where(lesson.lessonId.in(lessonIdList))
                 .execute();
     }
+
+    @Override
+    public Optional<LocalDate> findLessonDateByLessonId(Long lessonId) {
+        return Optional.ofNullable(
+                queryFactory.select(lesson.date)
+                        .from(lesson)
+                        .where(lesson.lessonId.in(lessonId), lesson.deletedAt.isNull())
+                        .fetchFirst()
+        );
+    }
 }

--- a/src/test/java/com/selfrunner/gwalit/domain/board/BoardServiceTest.java
+++ b/src/test/java/com/selfrunner/gwalit/domain/board/BoardServiceTest.java
@@ -9,6 +9,7 @@ import com.selfrunner.gwalit.domain.board.repository.FileRepository;
 import com.selfrunner.gwalit.domain.board.repository.ReplyRepository;
 import com.selfrunner.gwalit.domain.board.service.BoardService;
 import com.selfrunner.gwalit.domain.lecture.entity.Lecture;
+import com.selfrunner.gwalit.domain.lesson.repository.LessonRepository;
 import com.selfrunner.gwalit.domain.member.entity.Member;
 import com.selfrunner.gwalit.domain.member.entity.MemberAndLecture;
 import com.selfrunner.gwalit.domain.member.repository.MemberAndLectureRepository;
@@ -53,6 +54,9 @@ public class BoardServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private LessonRepository lessonRepository;
+
+    @Mock
     private MemberAndLectureRepository memberAndLectureRepository;
 
     @Mock
@@ -69,7 +73,7 @@ public class BoardServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        boardService = new BoardService(boardRepository, replyRepository, fileRepository, fileJdbcRepository, memberRepository, memberAndLectureRepository, notificationRepository, memberAndNotificationJdbcRepository, s3Client, fcmClient);
+        boardService = new BoardService(boardRepository, replyRepository, fileRepository, fileJdbcRepository, memberRepository, lessonRepository, memberAndLectureRepository, notificationRepository, memberAndNotificationJdbcRepository, s3Client, fcmClient);
     }
 
     @Test


### PR DESCRIPTION
## IssueName
게시글 API 추가 및 로직 수정

## Description
 - BoardReplyRes에서 Reply 부분들 전부 제거하고, ReplyCount만 반환
 - 댓글 페이지네이션 오래된 순으로 변경
 - 특정 게시글 하나 반환 시, 댓글의 파일도 가져와지는 오류 수정
 - 메인 화면 질문글 API 질문카테고리만 반환되도록
 - lessonDate 같이 반환하도록 수정