### PR TITLE
Fix: 파일 개수 5개 제한 검증 로직 추가

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/board/dto/request/PutBoardReq.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/dto/request/PutBoardReq.java
@@ -19,5 +19,6 @@ public class PutBoardReq {
     @NotNull
     private String status;
 
+    @NotNull
     private List<String> deleteFileList;
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryCustom.java
@@ -18,4 +18,7 @@ public interface FileRepositoryCustom {
 
     // 삭제될 파일용량들 조회 쿼리
     Long findDeleteCapacityByUrlList(List<String> urlList);
+
+    // 게시글에 해당하는 파일 개수 조회 쿼리
+    Long findCountByBoardId(Long boardId);
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/FileRepositoryImpl.java
@@ -58,4 +58,12 @@ public class FileRepositoryImpl implements FileRepositoryCustom{
                 .where(file.url.in(urlList), file.deletedAt.isNull())
                 .fetchFirst();
     }
+
+    @Override
+    public Long findCountByBoardId(Long boardId) {
+        return queryFactory.select(file.count())
+                .from(file)
+                .where(file.boardId.eq(boardId), file.replyId.isNull(), file.deletedAt.isNull())
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
@@ -61,9 +61,12 @@ public class BoardService {
     public BoardRes registerBoard(Member member, List<MultipartFile> multipartFileList, PostBoardReq postBoardReq) {
         // Validation
         MemberAndLecture memberAndLecture = memberAndLectureRepository.findMemberAndLectureByMemberAndLectureLectureId(member, postBoardReq.getLectureId()).orElseThrow(() -> new BoardException(ErrorCode.UNAUTHORIZED_EXCEPTION));
-        // TODO: 클래스당 용량 검사 로직 추가 필요
+        // 파일 개수 최대 5개 제한 로직 && 클래스당 용량 검사 로직 추가 필요
         if(multipartFileList != null && checkFileCapacity(memberAndLecture.getLecture().getLectureId(), multipartFileList, null)) {
             throw new BoardException(ErrorCode.TOTAL_SIZE_EXCEED);
+        }
+        if(multipartFileList != null && multipartFileList.size() > 5) {
+            throw new BoardException(ErrorCode.TOTAL_FILE_EXCEED);
         }
 
         // Business Logic
@@ -89,6 +92,9 @@ public class BoardService {
         // 파일 용량 확인 로직 필요 (1. 각 파일당 5MB 이하인지 2.삭제 후 남은 용량에서 해당 파일들 넣을 수 있는 용량이 남아있는지)
         if(multipartFileList != null && checkFileCapacity(board.getLecture().getLectureId(), multipartFileList, putBoardReq.getDeleteFileList())) {
             throw new BoardException(ErrorCode.TOTAL_SIZE_EXCEED);
+        }
+        if(multipartFileList != null && (multipartFileList.size() > 5 || (multipartFileList.size() - putBoardReq.getDeleteFileList().size() + fileRepository.findCountByBoardId(boardId) > 5))) {
+            throw new BoardException(ErrorCode.TOTAL_FILE_EXCEED);
         }
 
         // Business Logic (삭제되는 파일 지우고, 업로드할 파일 만들기)
@@ -188,6 +194,9 @@ public class BoardService {
         // 클래스당 용량 검사 로직 추가
         if(multipartFileList != null && checkFileCapacity(board.getLecture().getLectureId(), multipartFileList, null)) {
             throw new BoardException(ErrorCode.TOTAL_SIZE_EXCEED);
+        }
+        if(multipartFileList != null && multipartFileList.size() > 5) {
+            throw new BoardException(ErrorCode.TOTAL_FILE_EXCEED);
         }
 
         // Business Logic

--- a/src/main/java/com/selfrunner/gwalit/global/exception/ErrorCode.java
+++ b/src/main/java/com/selfrunner/gwalit/global/exception/ErrorCode.java
@@ -64,7 +64,8 @@ public enum ErrorCode {
     // Board
     FILE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, 10000, "파일 용량을 초과했습니다."),
     TOTAL_SIZE_EXCEED(HttpStatus.BAD_REQUEST, 10001, "전체 용량을 초과했습니다."),
-    NOT_QUESTION_STATUS(HttpStatus.BAD_REQUEST, 10002, "질문이 아닌 게시글입니다.");
+    NOT_QUESTION_STATUS(HttpStatus.BAD_REQUEST, 10002, "질문이 아닌 게시글입니다."),
+    TOTAL_FILE_EXCEED(HttpStatus.BAD_REQUEST, 10003, "첨부파일의 개수를 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
## IssueName
파일 개수 5개 제한 검증 로직 추가

## Description
게시글 작성 시, 등록할 수 있는 파일의 개수가 5개가 되도록 추가
게시글 수정 시, 등록할 수 있는 파일의 개수가 5개가 되도록 추가
댓글 작성 시, 등록할 수 있는 파일의 개수가 5개가 되도록 추가
