### PR TITLE
Fix: 게시글 오류 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryCustom.java
@@ -4,6 +4,7 @@ package com.selfrunner.gwalit.domain.board.repository;
 import com.selfrunner.gwalit.domain.board.dto.response.BoardMetaRes;
 import com.selfrunner.gwalit.domain.board.entity.Board;
 import com.selfrunner.gwalit.domain.board.enumerate.BoardCategory;
+import com.selfrunner.gwalit.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -14,7 +15,7 @@ import java.util.Optional;
 public interface BoardRepositoryCustom {
 
     // 카테고리별 게시글 페이지네이션
-    Slice<BoardMetaRes> findBoardPaginationByCategory(Long memberId, Long lectureId, BoardCategory category, Long cursor, LocalDateTime cursorCreatedAt, Pageable pageable);
+    Slice<BoardMetaRes> findBoardPaginationByCategory(Member member, Long lectureId, BoardCategory category, Long cursor, LocalDateTime cursorCreatedAt, Pageable pageable);
 
     // 해당 게시글을 작성한 클래스에 소속되어 있는지를 확인하고 게시글 정보를 반환
     Optional<Board> findBoardByMemberIdAndBoardId(Long memberId, Long boardId);

--- a/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
@@ -103,7 +103,10 @@ public class BoardService {
         board.update(putBoardReq);
         Board updateBoard = boardRepository.save(board);
         LocalDate lessonDate = (board.getLessonId() != null) ? lessonRepository.findLessonDateByLessonId(board.getLessonId()).orElse(null) : null;
-        List<FileRes> fileResList = (multipartFileList != null) ? uploadFileList(multipartFileList, member.getMemberId(), board.getLecture().getLectureId(), boardId, null) : null;
+        if(multipartFileList != null) {
+            uploadFileList(multipartFileList, member.getMemberId(), board.getLecture().getLectureId(), boardId, null);
+        }
+        List<FileRes> fileResList = fileRepository.findAllByBoardId(boardId).orElse(null);
         Integer replyCount = replyRepository.findReplyCountByBoardId(boardId);
 
         // Response

--- a/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/service/BoardService.java
@@ -174,6 +174,15 @@ public class BoardService {
         return new BoardReplyRes(board, board.getMember(), lessonDate, replyCount, fileList);
     }
 
+    /**
+     * 게시글 페이지네이션 (선생님일 때는 isPublic이 True와 False가 상관이 없음. / 학생일 때는, isPublic이 True이거나 false이면서 자신이 작성한 글이 보여야 함
+     * @param member - API 요청 사용자
+     * @param lectureId - 게시글이 포함되는 lectureId
+     * @param category - 게시글 분류
+     * @param cursor - 현재 커서
+     * @param pageable - 페이지네이션 객체
+     * @return 커서 기반 페이지네이션 결과값 (Slice 형태)
+     */
     public Slice<BoardMetaRes> getBoardPagination(Member member, Long lectureId, String category, Long cursor, Pageable pageable) {
         // Validation
         memberAndLectureRepository.findMemberAndLectureByMemberAndLectureLectureId(member, lectureId).orElseThrow(() -> new BoardException(ErrorCode.UNAUTHORIZED_EXCEPTION));
@@ -182,7 +191,7 @@ public class BoardService {
         LocalDateTime cursorCreatedAt = (cursor != null) ? boardRepository.findById(cursor).map(BaseTimeEntity::getCreatedAt).orElse(null) : null;
 
         // Response
-        return boardRepository.findBoardPaginationByCategory(member.getMemberId(), lectureId, (!category.equals("ALL")) ? BoardCategory.valueOf(category) : null, cursor, cursorCreatedAt, pageable);
+        return boardRepository.findBoardPaginationByCategory(member, lectureId, (!category.equals("ALL")) ? BoardCategory.valueOf(category) : null, cursor, cursorCreatedAt, pageable);
     }
 
     public List<BoardMetaRes> getOpenQuestion(Member member) {


### PR DESCRIPTION
## IssueName
게시글 오류 수정

## Description
클라이언트 테스트 과정에서 아래 오류 발생에 따른 오류 수정
1. 게시글수정api 결과 반환값에 새로 첨부한 파일 말고 기존게시글에 있던 파일은 포함 안 돼있음
2. 파일 여러개 첨부하여 댓글 작성 -> 댓글이 여러개 작성된걸로 보임(각 댓글마다 첨부파일이 하나씩)
3. 게시글이 작성자한테밖에 안보임 (쿼리 수정)