### PR TITLE
Fix: 게시글 페이지네이션 쿼리 오류 수정

### DIFF
--- a/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/selfrunner/gwalit/domain/board/repository/BoardRepositoryImpl.java
@@ -40,7 +40,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                     .leftJoin(lecture).on(board.lecture.lectureId.eq(lecture.lectureId))
                     .leftJoin(member).on(board.member.memberId.eq(member.memberId))
                     .leftJoin(reply).on(board.boardId.eq(reply.board.boardId))
-                    .where(board.lecture.lectureId.eq(lectureId), eqCursorAndCursorCreatedAt(cursor, cursorCreatedAt), checkCategory(category), board.deletedAt.isNull())
+                    .where(board.lecture.lectureId.eq(lectureId), eqCursorAndCursorCreatedAt(cursor, cursorCreatedAt), checkCategory(category), board.deletedAt.isNull(), reply.deletedAt.isNull())
                     .orderBy(board.createdAt.desc(), board.boardId.asc())
                     .groupBy(board.boardId)
                     .limit(pageable.getPageSize() + 1)


### PR DESCRIPTION
## IssueName
게시글 페이지네이션 쿼리 오류 수정

## Description
게시글 페이지네이션 쿼리 오류 수정
상세 상황: 260번 클래스에서 게시글 페이지네이션하면 7번 게시글이 replyCount가 1로 뜨는데, 특정 게시물 가져오기로 가져오면 replyCount가 0으로 뜸.